### PR TITLE
fix: Replace VALUES() by alias in upsert method

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -62,10 +62,11 @@ class Context {
      * @param {string}                  table
      * @param {Object|Array.<Object>}   data
      * @param {Array.<string>|Object}   update
+     * @param {?string}                 [alias=new]
      * @return {Promise}
      */
-    upsert(table, data, update) {
-        const sql = upsertStmt(table, data, update);
+    upsert(table, data, update, alias = 'new') {
+        const sql = upsertStmt(table, data, update, alias);
         return this.exec(sql);
     }
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -67,10 +67,11 @@ class Transaction {
      * @param {string}                  table
      * @param {Object|Array.<Object>}   data
      * @param {Array.<string>|Object}   update
+     * @param {?string}                 [alias=new]
      * @return {Promise}
      */
-    upsert(table, data, update) {
-        const sql = upsertStmt(table, data, update);
+    upsert(table, data, update, alias = 'new') {
+        const sql = upsertStmt(table, data, update, alias);
         return this.exec(sql).then(({ affectedRows, changedRows }) => ({ affectedRows, changedRows }));
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -133,14 +133,15 @@ function deleteStmt(table, where) {
  * @param {string}                  table
  * @param {Object|Array.<Object>}   data
  * @param {Array.<string>|Object}   update
+ * @param {string}                  alias
  * @return {string}
  */
-function upsertStmt(table, data, update) {
+function upsertStmt(table, data, update, alias) {
     if (!update || typeof update !== 'object') {
         throw new ImplementationError('Update parameter must be either an object or an array of strings');
     }
 
-    const sql = insertStmt(table, data) + ' ON DUPLICATE KEY UPDATE ';
+    const sql = `${insertStmt(table, data)} AS ${escapeId(alias)} ON DUPLICATE KEY UPDATE `;
 
     if (!Array.isArray(update) && isIterable(update)) {
         return (
@@ -152,7 +153,7 @@ function upsertStmt(table, data, update) {
     }
 
     if (Array.isArray(update) && update.every((item) => typeof item === 'string')) {
-        return sql + update.map((column) => escapeId(column) + ' = VALUES(' + escapeId(column) + ')').join(', ');
+        return sql + update.map((column) => `${escapeId(column)} = ${escapeId(alias)}.${escapeId(column)}`).join(', ');
     }
 
     return sql;


### PR DESCRIPTION
> The use of [VALUES()](https://dev.mysql.com/doc/refman/8.4/en/miscellaneous-functions.html#function_values) to refer to the new row and columns is deprecated, and subject to removal in a future version of MySQL. Instead, use row and column aliases, as described in the next few paragraphs of this section.

https://dev.mysql.com/doc/refman/8.4/en/insert-on-duplicate.html